### PR TITLE
make pep8 pass on families folder with --max-line-length=100

### DIFF
--- a/families/wikisourceorg_family.py
+++ b/families/wikisourceorg_family.py
@@ -10,6 +10,7 @@ Please do not commit this to the Git repository!
 
 from pywikibot import family
 
+
 class Family(family.Family):
     def __init__(self):
         family.Family.__init__(self)
@@ -17,8 +18,6 @@ class Family(family.Family):
         self.langs = {
             'mul': 'wikisource.org',
         }
-
-
 
     def scriptpath(self, code):
         return {

--- a/families/wmfwiki_family.py
+++ b/families/wmfwiki_family.py
@@ -10,6 +10,7 @@ Please do not commit this to the Git repository!
 
 from pywikibot import family
 
+
 class Family(family.Family):
     def __init__(self):
         family.Family.__init__(self)
@@ -17,8 +18,6 @@ class Family(family.Family):
         self.langs = {
             'wmfwiki': 'wikimediafoundation.org',
         }
-
-
 
     def scriptpath(self, code):
         return {


### PR DESCRIPTION
Fixed 4 errors:

```
families/wikisourceorg_family.py:13:1: E302 expected 2 blank lines, found 1
families/wikisourceorg_family.py:23:5: E303 too many blank lines (3)
families/wmfwiki_family.py:13:1: E302 expected 2 blank lines, found 1
families/wmfwiki_family.py:23:5: E303 too many blank lines (3)
```

They were caused by a Pywikibot bug, now resolved with https://gerrit.wikimedia.org/r/192840.
