### PR TITLE
make pep8 pass on mrmetadata.py with --max-line-length=256

### DIFF
--- a/mrmetadata.py
+++ b/mrmetadata.py
@@ -1,4 +1,4 @@
- #!/usr/bin/python
+#!/usr/bin/python
 
 import os
 import io
@@ -20,96 +20,96 @@ from pygal.style import LightSolarizedStyle
 
 SEP = '\n_________________________________\n\n'
 
-template_loader = jinja2.FileSystemLoader( searchpath="templates/" )
+template_loader = jinja2.FileSystemLoader(searchpath="templates/")
 
-template_env = jinja2.Environment( loader=template_loader )
+template_env = jinja2.Environment(loader=template_loader)
 
 config2.register_families_folder('families')
 
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
 #                                      main
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
+
 
 def main(args):
-    
+
     if (args.family and args.prefix):
-       check_local_uploads(args.family, args.prefix)
-       return
-    
+        check_local_uploads(args.family, args.prefix)
+        return
+
     if args.commons:
         check_local_uploads("commons", "commons", True)
         return
-    
+
     json_list = args.json
-    
+
     resume = args.resume
-    
+
     if not json_list:
         json_list = 'sites_with_local_uploads.json'
 
     cycle_through_wikis(json_list, resume)
-    
-    
-#--------------------------------------------------------------------------------
+
+
+# --------------------------------------------------------------------------------
 #                         get files and check metadata
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
 
 def cycle_through_wikis(json_list, resume):
 
     with open(json_list, 'r') as sites_with_local_uploads:
-    
+
         wikis = json.load(sites_with_local_uploads)
-        print SEP+u'Loaded wikis from JSON'+SEP
-        
+        print SEP + u'Loaded wikis from JSON' + SEP
+
         wikis = collections.OrderedDict(sorted(wikis.items(), key=lambda t: t[0]))      # Make sure our dict is always in the same order
 
         if resume:
             resume_from = get_resume_point(json_list)
-            
+
         for family in wikis:
-            
-            if resume and (family <> resume_from['family']):
+
+            if resume and (family != resume_from['family']):
                 pass
             else:
                 for prefix in wikis[family]:
-                    if resume and (prefix <> resume_from['prefix']):
+                    if resume and (prefix != resume_from['prefix']):
                         pass
                     else:
                         print u'Started run through {0}'.format(family)
-                        
+
                         check_local_uploads(family, prefix)
                         set_resume_point(json_list, family, prefix)
                         resume = False
-            
-            
+
 
 def check_local_uploads(family, prefix, commons=False):
-            
-    print SEP+u'Started run through {0}.{1}'.format(prefix, family)
+
+    print SEP + u'Started run through {0}.{1}'.format(prefix, family)
 
     output_directory_prefix = 'public_html/'
     output_directory = output_directory_prefix + family + '/' + prefix
     if not os.path.exists(output_directory):      # Create language directory if it doesn't exist
         os.makedirs(output_directory)
 
-    site_tally = {  'prefix': prefix,
-                    'family': family,
-                    'number_of_files': 0,
-                    'number_of_files_with_missing_mrd': 0,
-                    'percentage_ok': 0,
-                    'last_updated_on': None
-                    }
+    site_tally = {'prefix': prefix,
+                  'family': family,
+                  'number_of_files': 0,
+                  'number_of_files_with_missing_mrd': 0,
+                  'percentage_ok': 0,
+                  'last_updated_on': None
+                  }
 
     start_checking_site = time.clock()
-            
+
     REQUEST_FILES_BY_BATCHES_OF = 3000
-            
+
     API_STEP = 200
 
-    CHECK_FILES_BY_BATCHES_OF = 50 # Max value is 50
+    CHECK_FILES_BY_BATCHES_OF = 50  # Max value is 50
 
     NUMBER_OF_FILES_PER_PAGE = 500
-    
+
     commons_byte_index = 0
 
     current_site = pywikibot.Site(prefix, family)
@@ -120,7 +120,7 @@ def check_local_uploads(family, prefix, commons=False):
         batch_of_files, commons_byte_index = get_batch_of_Commons_files(REQUEST_FILES_BY_BATCHES_OF, commons_byte_index)
     else:
         batch_of_files = get_batch_of_files(current_site, REQUEST_FILES_BY_BATCHES_OF, API_STEP, start)
-            
+
     files_with_missing_mrd = []
 
     page_number = 1
@@ -134,68 +134,65 @@ def check_local_uploads(family, prefix, commons=False):
         files_with_missing_mrd = []
 
         site_tally['number_of_files'] = site_tally['number_of_files'] + len(batch_of_files)
-        
+
         # Is there another batch after that? If so, save where to start it
 
         another_batch_is_coming = len(batch_of_files) == REQUEST_FILES_BY_BATCHES_OF
 
-        if ( another_batch_is_coming ):
-            
+        if (another_batch_is_coming):
+
             if not commons:
-                start = batch_of_files[-1].title(withNamespace = False).encode('utf-8')
-                #print u'Next batch will start at {0}'.format(start) #debug
-                    
+                start = batch_of_files[-1].title(withNamespace=False).encode('utf-8')
+                # print u'Next batch will start at {0}'.format(start) #debug
+
             batch_of_files = batch_of_files[:-1]
 
         # Check the files in our batch for machine-readable metadata
 
         while len(batch_of_files):
-            
+
             files_with_missing_mrd = files_with_missing_mrd + check_metadata(current_site, batch_of_files[:CHECK_FILES_BY_BATCHES_OF])
             batch_of_files = batch_of_files[CHECK_FILES_BY_BATCHES_OF:]
-        
+
         site_tally['number_of_files_with_missing_mrd'] = len(files_with_missing_mrd) + site_tally['number_of_files_with_missing_mrd']
 
-
         # Output pages if we have enough files to list
-        
+
         # print "We have {0} files with missing MRD in this batch, and {1} total".format(len(files_with_missing_mrd), site_tally['number_of_files_with_missing_mrd']) # debug
-        
-      
+
         while (len(files_with_missing_mrd) >= NUMBER_OF_FILES_PER_PAGE):
 
             # We take the first page out to print it at the end (so we have can display the tally)
 
             if not len(files_to_print_on_the_first_page):
                 files_to_print_on_the_first_page = list(files_with_missing_mrd[:NUMBER_OF_FILES_PER_PAGE])
-                
+
             else:
 
-            # We've got enough files to print a page; print them and remove them from the queue
+                # We've got enough files to print a page; print them and remove them from the queue
 
-                output_site_page(output_directory, page_number, current_site, files_with_missing_mrd[:NUMBER_OF_FILES_PER_PAGE], NUMBER_OF_FILES_PER_PAGE )
-                    
+                output_site_page(output_directory, page_number, current_site, files_with_missing_mrd[:NUMBER_OF_FILES_PER_PAGE], NUMBER_OF_FILES_PER_PAGE)
+
             page_number = page_number + 1
 
             files_with_missing_mrd = files_with_missing_mrd[NUMBER_OF_FILES_PER_PAGE:]
-                    
+
             if len(files_with_missing_mrd):
                 all_files_are_on_first_page = False
 
         # If we haven't had enough to fill several pages, add what we have to the first page
-                
+
         if not len(files_to_print_on_the_first_page):
             files_to_print_on_the_first_page = list(files_with_missing_mrd[:NUMBER_OF_FILES_PER_PAGE])
 
-
         # We're done with this batch, request another one
-                
-        if ( another_batch_is_coming ):
+
+        if (another_batch_is_coming):
             if commons:
                 batch_of_files, commons_byte_index = get_batch_of_Commons_files(REQUEST_FILES_BY_BATCHES_OF, commons_byte_index)
             else:
                 batch_of_files = get_batch_of_files(current_site, REQUEST_FILES_BY_BATCHES_OF, API_STEP, start)
-                    
+
         else:
             # If we're still on the first page, dump all the remaining files there
 
@@ -206,10 +203,9 @@ def check_local_uploads(family, prefix, commons=False):
 
     if len(files_with_missing_mrd) and not all_files_are_on_first_page:
 
-        output_site_page(output_directory, page_number, current_site, files_with_missing_mrd, NUMBER_OF_FILES_PER_PAGE, last_page = True )
+        output_site_page(output_directory, page_number, current_site, files_with_missing_mrd, NUMBER_OF_FILES_PER_PAGE, last_page=True)
 
-
-    done_checking_site = time.clock();
+    done_checking_site = time.clock()
     print u'Checked {0}.{1} in {2}s'.format(prefix, family, done_checking_site - start_checking_site)
 
     # Commons is special because, to save time during the check, we skip all the files transcluding templates we know have MRD markers.
@@ -219,142 +215,138 @@ def check_local_uploads(family, prefix, commons=False):
         site_tally['number_of_files'] = get_total_number_of_Commons_files()
 
     # Update the tallies
-            
+
     try:
-        site_tally['percentage_ok'] = int( 100 - ( site_tally['number_of_files_with_missing_mrd'] * 100 
-                                        / site_tally['number_of_files']) )
+        site_tally['percentage_ok'] = int(100 - (site_tally['number_of_files_with_missing_mrd'] * 100
+                                          / site_tally['number_of_files']))
     except ZeroDivisionError:
         site_tally['percentage_ok'] = 100           # No files on the wiki means there's nothing to fix
-            
+
     site_tally['last_updated_on'] = datetime.date.today().isoformat()
 
-    update_tallies( output_directory_prefix, site_tally )
-    
+    update_tallies(output_directory_prefix, site_tally)
+
     update_chart(output_directory_prefix, family, prefix)
-    
+
     update_main_chart(output_directory_prefix)
 
     # Print the first page now that we have the tallies
 
     site_tally['last_updated_on'] = datetime.date.today().isoformat()   # Re-add since we popped it while archiving
 
-    output_first_page(output_directory, current_site, files_to_print_on_the_first_page, NUMBER_OF_FILES_PER_PAGE, site_tally, last_page = all_files_are_on_first_page  )
+    output_first_page(output_directory, current_site, files_to_print_on_the_first_page, NUMBER_OF_FILES_PER_PAGE, site_tally, last_page=all_files_are_on_first_page)
 
-            
     update_main_page()                  # Update with numbers from the latest wiki that was checked
 
 
 def get_batch_of_Commons_files(REQUEST_FILES_BY_BATCHES_OF, position_in_file):
-    
+
     # There ought to be a better way to do this, but this'll do as a first step.
-    
-    batch_of_files=[]
+
+    batch_of_files = []
     site = pywikibot.Site('commons', 'commons')
-        
+
     with io.open('commons_list.txt', 'r', encoding='utf8') as commons_list_file:
-        
+
         commons_list_file.seek(position_in_file)
-        
+
         files_left_to_get = REQUEST_FILES_BY_BATCHES_OF
-        
+
         end_of_file = False
-        
+
         while not end_of_file and files_left_to_get:
-            
+
             previous_position_in_file = position_in_file
-            
+
             line = commons_list_file.readline()
-            
+
             position_in_file = commons_list_file.tell()
-            
-            title = line.strip();
-            
+
+            title = line.strip()
+
             if title:
                 page = pywikibot.Page(site, "File:" + title)
                 batch_of_files.append(page)
                 files_left_to_get = files_left_to_get - 1
-                
+
             else:
                 end_of_file = True
-        
-    commons_list_file.close()
-        
-    return batch_of_files, previous_position_in_file
 
+    commons_list_file.close()
+
+    return batch_of_files, previous_position_in_file
 
 
 def get_total_number_of_Commons_files():
 
     with io.open('commons_filecount.txt', 'r', encoding='utf8') as commons_count_file:
-                
-        commons_count_file.readline() # Ignore the first line (title)
-            
-        file_count = commons_count_file.readline()
-            
-    commons_count_file.close()
-    
-    file_count = file_count.strip();
-   
-    return int(file_count)
 
+        commons_count_file.readline()  # Ignore the first line (title)
+
+        file_count = commons_count_file.readline()
+
+    commons_count_file.close()
+
+    file_count = file_count.strip()
+
+    return int(file_count)
 
 
 def get_batch_of_files(current_site, batches_of, api_step, start_from):
 
     start_getting_allfiles = time.clock()
 
-    #print u'Requesting {0} files'.format(batches_of) #debug
-    
+    # print u'Requesting {0} files'.format(batches_of) #debug
+
     batch_of_files_generator = pagegenerators.AllpagesPageGenerator(site=current_site, start=start_from, namespace=6, includeredirects=False, total=batches_of, step=api_step, content=False)
 
-    done_getting_allfiles = time.clock();
-                            
-    batch_of_files=[]
+    done_getting_allfiles = time.clock()
+
+    batch_of_files = []
 
     for page in batch_of_files_generator:
         batch_of_files.append(page)
-                    
-    #print u'Got {0} pages in {1}s'.format(len(batch_of_files), done_getting_allfiles - start_getting_allfiles) #debug
+
+    # print u'Got {0} pages in {1}s'.format(len(batch_of_files), done_getting_allfiles - start_getting_allfiles) #debug
 
     return batch_of_files
 
 
-
 def check_metadata(current_site, pages):
-    
+
     start_checking_metadata = time.clock()
     number_of_pages_to_check = len(pages)
-    #print u'Checking metadata for {0} pages'.format(number_of_pages_to_check) #debug
+    # print u'Checking metadata for {0} pages'.format(number_of_pages_to_check) #debug
 
     titles = []
     files_with_missing_mrd = []
-    
+
     for i in range(0, number_of_pages_to_check):
         titles.append(pages[i].title(withSection=False))
-    
+
     args = {"titles": titles}
     args["total"] = number_of_pages_to_check
     query = current_site._generator(site.api.PropertyGenerator,
-                                type_arg="imageinfo",
-                                iiprop=["extmetadata"],
-                                **args)
-    
+                                    type_arg="imageinfo",
+                                    iiprop=["extmetadata"],
+                                    **args)
+
     for page in query:
-        
+
         no_mr_description = no_mr_author = no_mr_source = no_mr_license_short = no_mr_license_url = False
 
         repository = page['imagerepository']
-        
-        if repository <> "local":
+
+        if repository != "local":
             pass
         else:
 
             title = page['title']
-            
+
             try:
                 metadata = page['imageinfo'][0]['extmetadata']
-                #print u'checking metadata for "{0}"'.format(title) # for debugging
-                
+                # print u'checking metadata for "{0}"'.format(title) # for debugging
+
                 try:
                     mr_description = metadata['ImageDescription']['value']
                 except KeyError:
@@ -369,47 +361,46 @@ def check_metadata(current_site, pages):
                     mr_source = metadata['Credit']['value']
                 except KeyError:
                     no_mr_source = True
-                        
+
                 try:
                     mr_license_short = metadata['LicenseShortName']['value']
                 except KeyError:
                     no_mr_license_short = True
-                        
+
                 try:
                     mr_license_url = metadata['LicenseUrl']['value']
                 except KeyError:
                     no_mr_license_url = True
-                    
-                if ( no_mr_description and no_mr_author and no_mr_source or no_mr_license_short and no_mr_license_url):
+
+                if (no_mr_description and no_mr_author and no_mr_source or no_mr_license_short and no_mr_license_url):
                     files_with_missing_mrd.append([title, no_mr_description, no_mr_author, no_mr_source, no_mr_license_short, no_mr_license_url])
-                    #print "The file is missing required machine-readable metadata and has been added to the list." #debug
-                #else:
-                #    print "Everything looks good; moving on." #debug
-                            
-            except KeyError: #No imageinfo means no image, so skip
-                #print u'Skipping {0}'.format(title)
+                    # print "The file is missing required machine-readable metadata and has been added to the list." #debug
+                # else:
+                #     print "Everything looks good; moving on." #debug
+
+            except KeyError:  # No imageinfo means no image, so skip
+                # print u'Skipping {0}'.format(title)
                 pass
-                        
-    done_checking_metadata = time.clock();
-    #print u'Metadata checked in {0}s'.format(done_checking_metadata - start_checking_metadata)
 
-    return files_with_missing_mrd    
+    done_checking_metadata = time.clock()
+    # print u'Metadata checked in {0}s'.format(done_checking_metadata - start_checking_metadata)
+
+    return files_with_missing_mrd
 
 
-
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
 #                             Update / save tallies
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
 
-def update_tallies( output_directory_prefix, site_tally ):
+def update_tallies(output_directory_prefix, site_tally):
 
-    #TODO handle case where there are no more files on the wiki
+    # TODO handle case where there are no more files on the wiki
 
-    #Reminder: site_tally = {'prefix', 'family', 'number_of_files', 'number_of_files_with_missing_mrd', 'percentage_ok', 'last_updated_on'}
-    
+    # Reminder: site_tally = {'prefix', 'family', 'number_of_files', 'number_of_files_with_missing_mrd', 'percentage_ok', 'last_updated_on'}
+
     family = site_tally.pop('family')       # get those values and remove them to save time when we save the rest later
     prefix = site_tally.pop('prefix')
-        
+
     if not os.path.exists('tallies.json'):
         tallies = {}
     else:
@@ -417,94 +408,88 @@ def update_tallies( output_directory_prefix, site_tally ):
             tallies = json.load(tallies_file)
             tallies_file.close()
 
-
     # Get the existing site tally if they exist, else initialize them
-    
+
     try:
         old_site_tally = tallies[family][prefix]
     except KeyError:
-        old_site_tally = {  'number_of_files': 0,
-                            'number_of_files_with_missing_mrd': 0,
-                            'percentage_ok': 100}
-
+        old_site_tally = {'number_of_files': 0,
+                          'number_of_files_with_missing_mrd': 0,
+                          'percentage_ok': 100}
 
     # Get the existing global and family tallies if they exist, else initialize them
-        
-    
+
     try:
         global_tally = tallies['global']['global']              # We have a global tally set
     except KeyError:
-        global_tally = { 'number_of_files': 0,
-                         'number_of_files_with_missing_mrd': 0,
-                         'percentage_ok': 100
-                       }
-        
+        global_tally = {'number_of_files': 0,
+                        'number_of_files_with_missing_mrd': 0,
+                        'percentage_ok': 100
+                        }
+
     try:
         family_tally = tallies['global'][family]                     # We have a tally for this family in the global set
     except KeyError:
-        family_tally = { 'number_of_files': 0,
-                         'number_of_files_with_missing_mrd': 0,
-                         'percentage_ok': 100
-                       }
-              
-                
-                
+        family_tally = {'number_of_files': 0,
+                        'number_of_files_with_missing_mrd': 0,
+                        'percentage_ok': 100
+                        }
+
     # Update the family tally
-        
+
     family_tally['number_of_files'] = family_tally['number_of_files'] - old_site_tally['number_of_files'] + site_tally['number_of_files']
-       
+
     family_tally['number_of_files_with_missing_mrd'] = family_tally['number_of_files_with_missing_mrd'] - old_site_tally['number_of_files_with_missing_mrd'] + site_tally['number_of_files_with_missing_mrd']
-            
+
     try:
-        family_tally['percentage_ok'] =  int(100 - ( 100 * family_tally['number_of_files_with_missing_mrd'] / family_tally['number_of_files'] ))
+        family_tally['percentage_ok'] = int(100 - (100 * family_tally['number_of_files_with_missing_mrd'] / family_tally['number_of_files']))
     except ZeroDivisionError:                       # No files on a family
         site_tally['percentage_ok'] = 100           # Probably not gonna happen but let's be safe
-        
+
     family_tally['last_updated_on'] = site_tally['last_updated_on']
-        
+
     # Update the global tally
-        
+
     global_tally['number_of_files'] = global_tally['number_of_files'] - old_site_tally['number_of_files'] + site_tally['number_of_files']
-        
+
     global_tally['number_of_files_with_missing_mrd'] = global_tally['number_of_files_with_missing_mrd'] - old_site_tally['number_of_files_with_missing_mrd'] + site_tally['number_of_files_with_missing_mrd']
-                
-    global_tally['percentage_ok'] =  int(100 - ( 100 * global_tally['number_of_files_with_missing_mrd'] / global_tally['number_of_files'] ))
-    
+
+    global_tally['percentage_ok'] = int(100 - (100 * global_tally['number_of_files_with_missing_mrd'] / global_tally['number_of_files']))
+
     global_tally['last_updated_on'] = site_tally['last_updated_on']
-    
+
     # Write the updated tallies to the JSON file
-    
+
     with io.open('tallies.json', 'w', encoding='utf8') as tallies_file:
 
         try:
             tallies[family][prefix] = site_tally
         except KeyError:                                # We don't have any tallies for this family yet
-            tallies[family] = { prefix: site_tally }
-        
+            tallies[family] = {prefix: site_tally}
+
         try:
             tallies['global']['global'] = global_tally
         except KeyError:                                # We don't have global tallies yet
             tallies['global'] = {'global': global_tally}
-            
+
         tallies['global'][family] = family_tally
-                
-        tallies_file.write(unicode(json.dumps(tallies,indent=4,sort_keys=True,ensure_ascii=False)))
-              
+
+        tallies_file.write(unicode(json.dumps(tallies, indent=4, sort_keys=True, ensure_ascii=False)))
+
         tallies_file.truncate()
         tallies_file.close()
 
-
     # Archive the new tallies to the lists of historical tallies
-    
+
     archive_tally(site_tally, output_directory_prefix + family + '/' + prefix + '/historical_tallies.json')
     archive_tally(family_tally, output_directory_prefix + family + '/historical_tallies.json')
     archive_tally(global_tally, output_directory_prefix + '/historical_tallies.json')
-        
+
     print u'Updated tallies.'
 
 
 def archive_tally(tally, tally_archive_file_name):
-    
+
     if not os.path.exists(tally_archive_file_name):
         historical_tallies = {}
     else:
@@ -518,60 +503,59 @@ def archive_tally(tally, tally_archive_file_name):
     historical_tallies[timestamp] = tally
 
     with io.open(tally_archive_file_name, 'w', encoding='utf8') as historical_tallies_file:
-                
-        historical_tallies_file.write(unicode(json.dumps(historical_tallies,indent=4,sort_keys=True,ensure_ascii=False)))
-              
+
+        historical_tallies_file.write(unicode(json.dumps(historical_tallies, indent=4, sort_keys=True, ensure_ascii=False)))
+
         historical_tallies_file.truncate()
         historical_tallies_file.close()
 
 
-     
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
 #                              Resume a check (JSON only)
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
 
 def get_resume_point(json_list):
-    
-    with io.open('resume_'+json_list, 'r', encoding='utf8') as resume_file:
+
+    with io.open('resume_' + json_list, 'r', encoding='utf8') as resume_file:
         resume_point = json.load(resume_file)
         resume_file.close()
-        
+
     return resume_point
 
 
-
 def set_resume_point(json_list, family, prefix):
-    
+
     resume_point = {'family': family, 'prefix': prefix}
-    
-    with io.open('resume_'+json_list, 'w', encoding='utf8') as resume_file:       
-        resume_file.write(unicode(json.dumps(resume_point,indent=4,sort_keys=True,ensure_ascii=False)))
+
+    with io.open('resume_' + json_list, 'w', encoding='utf8') as resume_file:
+        resume_file.write(unicode(json.dumps(resume_point, indent=4, sort_keys=True, ensure_ascii=False)))
         resume_file.close()
 
 
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
 #                    Create and update historical charts
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
 
 def update_chart(output_directory_prefix, family, prefix):
-    
+
     historical_tallies_file_name = output_directory_prefix + family + '/' + prefix + '/' + 'historical_tallies.json'
 
     with open(historical_tallies_file_name, 'r') as historical_tallies_file:
         historical_tallies = json.load(historical_tallies_file)
-        historical_tallies_file.close()    
+        historical_tallies_file.close()
 
     output_file = output_directory_prefix + family + '/' + prefix + '/' + 'historical_tallies.svg'
 
     generate_chart(historical_tallies, output_file)
 
+
 def update_main_chart(output_directory_prefix):
-    
+
     historical_tallies_file_name = output_directory_prefix + 'historical_tallies.json'
 
     with open(historical_tallies_file_name, 'r') as historical_tallies_file:
         historical_tallies = json.load(historical_tallies_file)
-        historical_tallies_file.close()    
+        historical_tallies_file.close()
 
     output_file = output_directory_prefix + 'historical_tallies.svg'
 
@@ -579,12 +563,12 @@ def update_main_chart(output_directory_prefix):
 
 
 def generate_chart(historical_tallies, output_file):
-    
+
     bar_chart = pygal.Bar(show_legend=False, style=LightSolarizedStyle)
     bar_chart.add
-    
+
     historical_tallies = collections.OrderedDict(sorted(historical_tallies.items(), key=lambda t: t[0]))
-    
+
     historical_tallies.pop('last_updated_on')
 
     values_to_chart = []
@@ -595,21 +579,21 @@ def generate_chart(historical_tallies, output_file):
         values_to_chart.append(historical_tallies[date]['percentage_ok'])
 
     bar_chart.add('Percentage ok', values_to_chart)
-    
+
     bar_chart.x_labels = dates
 
     bar_chart.render_to_file(output_file)
 
 
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
 #                              Output HTML pages
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
 
 
 def update_main_page():
-    
-    template = template_env.get_template( 'main.html' )
-    
+
+    template = template_env.get_template('main.html')
+
     tallies = {}
 
     with io.open('tallies.json', 'r', encoding='utf8') as tallies_file:
@@ -620,17 +604,17 @@ def update_main_page():
         global_tallies = unsorted_tallies.pop('global')
     except KeyError:
         global_tallies = {}
-        
+
     alphabetical_tallies = collections.OrderedDict(sorted(unsorted_tallies.items(), key=lambda t: t[0]))
 
     for family in alphabetical_tallies:
-        alphabetical_tallies[family] = collections.OrderedDict(sorted(alphabetical_tallies[family].items(), key=lambda t: t[0]))    
-        
-    template_params = { 'global': global_tallies,
-                        'tallies': alphabetical_tallies
-                        }
+        alphabetical_tallies[family] = collections.OrderedDict(sorted(alphabetical_tallies[family].items(), key=lambda t: t[0]))
 
-    html_output = template.render( template_params )
+    template_params = {'global': global_tallies,
+                       'tallies': alphabetical_tallies
+                       }
+
+    html_output = template.render(template_params)
 
     file_name = 'public_html/index.html'
 
@@ -639,8 +623,7 @@ def update_main_page():
         f.close()
 
 
-
-def format_files ( files_to_print, current_site ):
+def format_files(files_to_print, current_site):
 
     MR_MISSING = '<td class="danger">missing</td>'
     MR_OK = '<td class="success">ok</td>'
@@ -651,44 +634,44 @@ def format_files ( files_to_print, current_site ):
     for item in files_to_print:
 
         file_title = item[0]
-        page = pywikibot.Page(source = current_site, title = file_title, ns = 6)
+        page = pywikibot.Page(source=current_site, title=file_title, ns=6)
         url = 'https://' + current_site.hostname() + '/wiki/' + page.title(asUrl=True)
 
         formatted_files_to_print.append({'index': item_index,
-            'title': file_title,
-            'url': url,
-            'description': MR_MISSING if item[1] else MR_OK,
-            'author': MR_MISSING if item[2] else MR_OK,
-            'source': MR_MISSING if item[3] else MR_OK,
-            'license_short': MR_MISSING if item[4] else MR_OK,
-            'license_url': MR_MISSING if item[5] else MR_OK})
-        
+                                         'title': file_title,
+                                         'url': url,
+                                         'description': MR_MISSING if item[1] else MR_OK,
+                                         'author': MR_MISSING if item[2] else MR_OK,
+                                         'source': MR_MISSING if item[3] else MR_OK,
+                                         'license_short': MR_MISSING if item[4] else MR_OK,
+                                         'license_url': MR_MISSING if item[5] else MR_OK})
+
         item_index = item_index + 1
 
     return formatted_files_to_print
 
 
-def output_site_page(output_directory, page_number, current_site, files_to_print, max_files_per_page, last_page = False, ):
-    
+def output_site_page(output_directory, page_number, current_site, files_to_print, max_files_per_page, last_page=False, ):
+
     # print "Outputting page: {0}".format(page_number) #debug
 
-    template = template_env.get_template( 'site_page.html' )
+    template = template_env.get_template('site_page.html')
 
-    formatted_list_of_files = format_files ( files_to_print, current_site)
-        
-    pages = {   'number': page_number,
-                'previous': 'index' if (page_number == 2) else str(page_number - 1).zfill(5),
-                'next': str(page_number + 1).zfill(5),
-                'is_last': last_page,
-            }
-    
-    template_params = { 'site' : str(current_site.sitename()),
-                    'pages': pages,
-                    'max_files_per_page': max_files_per_page,
-                    'formatted_list_of_files' : formatted_list_of_files,
-                    'return_to_root' : '../../'}
+    formatted_list_of_files = format_files(files_to_print, current_site)
 
-    html_output = template.render( template_params )
+    pages = {'number': page_number,
+             'previous': 'index' if (page_number == 2) else str(page_number - 1).zfill(5),
+             'next': str(page_number + 1).zfill(5),
+             'is_last': last_page,
+             }
+
+    template_params = {'site': str(current_site.sitename()),
+                       'pages': pages,
+                       'max_files_per_page': max_files_per_page,
+                       'formatted_list_of_files': formatted_list_of_files,
+                       'return_to_root': '../../'}
+
+    html_output = template.render(template_params)
 
     file_name = output_directory + '/' + str(page_number).zfill(5) + '.html'
 
@@ -697,26 +680,26 @@ def output_site_page(output_directory, page_number, current_site, files_to_print
         f.close()
 
 
-def output_first_page(output_directory, current_site, files_to_print, max_files_per_page, tallies, last_page = False, ):
+def output_first_page(output_directory, current_site, files_to_print, max_files_per_page, tallies, last_page=False, ):
 
-    template = template_env.get_template( 'site_page.html' )
+    template = template_env.get_template('site_page.html')
 
-    formatted_list_of_files = format_files ( files_to_print, current_site)
-    
-    pages = {   'number': 1,
-                'previous': '0',
-                'next': str(2).zfill(5),
-                'is_last': last_page,
-            }
+    formatted_list_of_files = format_files(files_to_print, current_site)
 
-    template_params = { 'site' : str(current_site.sitename()),
-                    'pages': pages,
-                    'max_files_per_page': max_files_per_page,
-                    'formatted_list_of_files' : formatted_list_of_files,
-                    'tallies': tallies,
-                    'return_to_root' : '../../'}
+    pages = {'number': 1,
+             'previous': '0',
+             'next': str(2).zfill(5),
+             'is_last': last_page,
+             }
 
-    html_output = template.render( template_params )
+    template_params = {'site': str(current_site.sitename()),
+                       'pages': pages,
+                       'max_files_per_page': max_files_per_page,
+                       'formatted_list_of_files': formatted_list_of_files,
+                       'tallies': tallies,
+                       'return_to_root': '../../'}
+
+    html_output = template.render(template_params)
 
     file_name = output_directory + '/index.html'
 
@@ -725,34 +708,33 @@ def output_first_page(output_directory, current_site, files_to_print, max_files_
         f.close()
 
 
-
-def format_number ( number ):
-    return '    {:,}'.format( number )
+def format_number(number):
+    return '    {:,}'.format(number)
 
 
 template_env.filters['format_number'] = format_number
 
 
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
 
 if __name__ == '__main__':
-    
+
     parser = argparse.ArgumentParser(description=u'Go through a wiki or a set of wikis and identify files missing machine-readable metadata')
-    
+
     parser.add_argument('--family', help=u'the family of the wiki to check')
-    
+
     parser.add_argument('--prefix', help=u'the prefix of the wiki to check')
-    
+
     parser.add_argument('--commons', action='store_const', const=True, help=u'check Commons')
-    
+
     parser.add_argument('--json', help=u'A JSON file containing a list of wikis to check')
-    
+
     parser.add_argument('--resume', action='store_const', const=True, help=u'Resume a check from a JSON file from the last wiki completed')
-    
+
     arguments = parser.parse_args()
-    
+
     try:
         main(arguments)
-       
+
     finally:
         pywikibot.stopme()


### PR DESCRIPTION
Fixed 300+ errors and warnings:

```
mrmetadata.py:1:2: E111 indentation is not a multiple of four
mrmetadata.py:1:2: E113 unexpected indentation
mrmetadata.py:23:43: E201 whitespace after '('
mrmetadata.py:23:67: E202 whitespace before ')'
mrmetadata.py:25:35: E201 whitespace after '('
mrmetadata.py:25:58: E202 whitespace before ')'
mrmetadata.py:29:1: E265 block comment should start with '# '
mrmetadata.py:31:1: E265 block comment should start with '# '
mrmetadata.py:33:1: E302 expected 2 blank lines, found 1
mrmetadata.py:34:1: W293 blank line contains whitespace
mrmetadata.py:36:8: E111 indentation is not a multiple of four
mrmetadata.py:37:8: E111 indentation is not a multiple of four
mrmetadata.py:38:1: W293 blank line contains whitespace
mrmetadata.py:42:1: W293 blank line contains whitespace
mrmetadata.py:44:1: W293 blank line contains whitespace
mrmetadata.py:46:1: W293 blank line contains whitespace
mrmetadata.py:51:1: W293 blank line contains whitespace
mrmetadata.py:52:1: W293 blank line contains whitespace
mrmetadata.py:53:1: E265 block comment should start with '# '
mrmetadata.py:55:1: E265 block comment should start with '# '
mrmetadata.py:60:1: W293 blank line contains whitespace
mrmetadata.py:63:1: W293 blank line contains whitespace
mrmetadata.py:68:1: W293 blank line contains whitespace
mrmetadata.py:70:1: W293 blank line contains whitespace
mrmetadata.py:71:35: W603 '<>' is deprecated, use '!='
mrmetadata.py:75:43: W603 '<>' is deprecated, use '!='
mrmetadata.py:79:1: W293 blank line contains whitespace
mrmetadata.py:83:1: W293 blank line contains whitespace
mrmetadata.py:84:1: W293 blank line contains whitespace
mrmetadata.py:86:1: E303 too many blank lines (3)
mrmetadata.py:87:1: W293 blank line contains whitespace
mrmetadata.py:95:19: E201 whitespace after '{'
mrmetadata.py:104:1: W293 blank line contains whitespace
mrmetadata.py:106:1: W293 blank line contains whitespace
mrmetadata.py:109:35: E261 at least two spaces before inline comment
mrmetadata.py:112:1: W293 blank line contains whitespace
mrmetadata.py:123:1: W293 blank line contains whitespace
mrmetadata.py:137:1: W293 blank line contains whitespace
mrmetadata.py:142:13: E201 whitespace after '('
mrmetadata.py:142:37: E202 whitespace before ')'
mrmetadata.py:143:1: W293 blank line contains whitespace
mrmetadata.py:145:63: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:145:65: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:146:17: E265 block comment should start with '# '
mrmetadata.py:147:1: W293 blank line contains whitespace
mrmetadata.py:153:1: W293 blank line contains whitespace
mrmetadata.py:156:1: W293 blank line contains whitespace
mrmetadata.py:160:9: E303 too many blank lines (2)
mrmetadata.py:161:1: W293 blank line contains whitespace
mrmetadata.py:163:1: W293 blank line contains whitespace
mrmetadata.py:164:1: W293 blank line contains whitespace
mrmetadata.py:165:9: E303 too many blank lines (2)
mrmetadata.py:171:1: W293 blank line contains whitespace
mrmetadata.py:174:13: E112 expected an indented block
mrmetadata.py:176:154: E202 whitespace before ')'
mrmetadata.py:177:1: W293 blank line contains whitespace
mrmetadata.py:181:1: W293 blank line contains whitespace
mrmetadata.py:186:1: W293 blank line contains whitespace
mrmetadata.py:191:9: E303 too many blank lines (2)
mrmetadata.py:192:1: W293 blank line contains whitespace
mrmetadata.py:193:13: E201 whitespace after '('
mrmetadata.py:193:37: E202 whitespace before ')'
mrmetadata.py:198:1: W293 blank line contains whitespace
mrmetadata.py:209:130: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:209:132: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:209:137: E202 whitespace before ')'
mrmetadata.py:212:5: E303 too many blank lines (2)
mrmetadata.py:212:38: E703 statement ends with a semicolon
mrmetadata.py:222:1: W293 blank line contains whitespace
mrmetadata.py:224:43: E201 whitespace after '('
mrmetadata.py:224:51: E201 whitespace after '('
mrmetadata.py:224:104: W291 trailing whitespace
mrmetadata.py:225:41: E128 continuation line under-indented for visual indent
mrmetadata.py:225:73: E202 whitespace before ')'
mrmetadata.py:228:1: W293 blank line contains whitespace
mrmetadata.py:231:20: E201 whitespace after '('
mrmetadata.py:231:56: E202 whitespace before ')'
mrmetadata.py:232:1: W293 blank line contains whitespace
mrmetadata.py:234:1: W293 blank line contains whitespace
mrmetadata.py:241:136: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:241:138: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:241:167: E202 whitespace before ')'
mrmetadata.py:243:1: W293 blank line contains whitespace
mrmetadata.py:244:5: E303 too many blank lines (2)
mrmetadata.py:248:1: W293 blank line contains whitespace
mrmetadata.py:250:1: W293 blank line contains whitespace
mrmetadata.py:251:19: E225 missing whitespace around operator
mrmetadata.py:253:1: W293 blank line contains whitespace
mrmetadata.py:255:1: W293 blank line contains whitespace
mrmetadata.py:257:1: W293 blank line contains whitespace
mrmetadata.py:259:1: W293 blank line contains whitespace
mrmetadata.py:261:1: W293 blank line contains whitespace
mrmetadata.py:263:1: W293 blank line contains whitespace
mrmetadata.py:265:1: W293 blank line contains whitespace
mrmetadata.py:267:1: W293 blank line contains whitespace
mrmetadata.py:269:1: W293 blank line contains whitespace
mrmetadata.py:270:33: E703 statement ends with a semicolon
mrmetadata.py:271:1: W293 blank line contains whitespace
mrmetadata.py:276:1: W293 blank line contains whitespace
mrmetadata.py:279:1: W293 blank line contains whitespace
mrmetadata.py:281:1: W293 blank line contains whitespace
mrmetadata.py:286:1: E303 too many blank lines (3)
mrmetadata.py:289:1: W293 blank line contains whitespace
mrmetadata.py:290:38: E261 at least two spaces before inline comment
mrmetadata.py:291:1: W293 blank line contains whitespace
mrmetadata.py:293:1: W293 blank line contains whitespace
mrmetadata.py:295:1: W293 blank line contains whitespace
mrmetadata.py:296:36: E703 statement ends with a semicolon
mrmetadata.py:297:1: W293 blank line contains whitespace
mrmetadata.py:302:1: E303 too many blank lines (3)
mrmetadata.py:306:5: E265 block comment should start with '# '
mrmetadata.py:307:1: W293 blank line contains whitespace
mrmetadata.py:310:41: E703 statement ends with a semicolon
mrmetadata.py:311:1: W293 blank line contains whitespace
mrmetadata.py:312:19: E225 missing whitespace around operator
mrmetadata.py:316:1: W293 blank line contains whitespace
mrmetadata.py:317:5: E265 block comment should start with '# '
mrmetadata.py:323:1: E303 too many blank lines (3)
mrmetadata.py:324:1: W293 blank line contains whitespace
mrmetadata.py:327:5: E265 block comment should start with '# '
mrmetadata.py:331:1: W293 blank line contains whitespace
mrmetadata.py:334:1: W293 blank line contains whitespace
mrmetadata.py:338:33: E128 continuation line under-indented for visual indent
mrmetadata.py:339:33: E128 continuation line under-indented for visual indent
mrmetadata.py:340:33: E128 continuation line under-indented for visual indent
mrmetadata.py:341:1: W293 blank line contains whitespace
mrmetadata.py:343:1: W293 blank line contains whitespace
mrmetadata.py:347:1: W293 blank line contains whitespace
mrmetadata.py:348:23: W603 '<>' is deprecated, use '!='
mrmetadata.py:353:1: W293 blank line contains whitespace
mrmetadata.py:356:17: E265 block comment should start with '# '
mrmetadata.py:357:1: W293 blank line contains whitespace
mrmetadata.py:372:1: W293 blank line contains whitespace
mrmetadata.py:377:1: W293 blank line contains whitespace
mrmetadata.py:382:1: W293 blank line contains whitespace
mrmetadata.py:383:21: E201 whitespace after '('
mrmetadata.py:385:21: E265 block comment should start with '# '
mrmetadata.py:386:17: E265 block comment should start with '# '
mrmetadata.py:388:1: W293 blank line contains whitespace
mrmetadata.py:389:29: E261 at least two spaces before inline comment
mrmetadata.py:389:30: E262 inline comment should start with '# '
mrmetadata.py:390:17: E265 block comment should start with '# '
mrmetadata.py:392:1: W293 blank line contains whitespace
mrmetadata.py:393:42: E703 statement ends with a semicolon
mrmetadata.py:394:5: E265 block comment should start with '# '
mrmetadata.py:396:34: W291 trailing whitespace
mrmetadata.py:400:1: E265 block comment should start with '# '
mrmetadata.py:400:1: E303 too many blank lines (3)
mrmetadata.py:402:1: E265 block comment should start with '# '
mrmetadata.py:404:1: E302 expected 2 blank lines, found 3
mrmetadata.py:404:20: E201 whitespace after '('
mrmetadata.py:404:56: E202 whitespace before ')'
mrmetadata.py:406:5: E265 block comment should start with '# '
mrmetadata.py:408:5: E265 block comment should start with '# '
mrmetadata.py:409:1: W293 blank line contains whitespace
mrmetadata.py:412:1: W293 blank line contains whitespace
mrmetadata.py:421:5: E303 too many blank lines (2)
mrmetadata.py:422:1: W293 blank line contains whitespace
mrmetadata.py:426:27: E201 whitespace after '{'
mrmetadata.py:431:5: E303 too many blank lines (2)
mrmetadata.py:432:1: W293 blank line contains whitespace
mrmetadata.py:433:1: W293 blank line contains whitespace
mrmetadata.py:434:5: E303 too many blank lines (2)
mrmetadata.py:437:25: E201 whitespace after '{'
mrmetadata.py:440:24: E124 closing bracket does not match visual indentation
mrmetadata.py:441:1: W293 blank line contains whitespace
mrmetadata.py:445:25: E201 whitespace after '{'
mrmetadata.py:448:24: E124 closing bracket does not match visual indentation
mrmetadata.py:449:1: W293 blank line contains whitespace
mrmetadata.py:450:1: W293 blank line contains whitespace
mrmetadata.py:451:1: W293 blank line contains whitespace
mrmetadata.py:452:5: E303 too many blank lines (3)
mrmetadata.py:453:1: W293 blank line contains whitespace
mrmetadata.py:455:1: W293 blank line contains whitespace
mrmetadata.py:457:1: W293 blank line contains whitespace
mrmetadata.py:459:40: E222 multiple spaces after operator
mrmetadata.py:459:53: E201 whitespace after '('
mrmetadata.py:459:142: E202 whitespace before ')'
mrmetadata.py:462:1: W293 blank line contains whitespace
mrmetadata.py:464:1: W293 blank line contains whitespace
mrmetadata.py:466:1: W293 blank line contains whitespace
mrmetadata.py:468:1: W293 blank line contains whitespace
mrmetadata.py:470:1: W293 blank line contains whitespace
mrmetadata.py:471:36: E222 multiple spaces after operator
mrmetadata.py:471:49: E201 whitespace after '('
mrmetadata.py:471:138: E202 whitespace before ')'
mrmetadata.py:472:1: W293 blank line contains whitespace
mrmetadata.py:474:1: W293 blank line contains whitespace
mrmetadata.py:476:1: W293 blank line contains whitespace
mrmetadata.py:482:32: E201 whitespace after '{'
mrmetadata.py:482:51: E202 whitespace before '}'
mrmetadata.py:483:1: W293 blank line contains whitespace
mrmetadata.py:488:1: W293 blank line contains whitespace
mrmetadata.py:490:1: W293 blank line contains whitespace
mrmetadata.py:491:54: E231 missing whitespace after ','
mrmetadata.py:491:63: E231 missing whitespace after ','
mrmetadata.py:491:78: E231 missing whitespace after ','
mrmetadata.py:492:1: W293 blank line contains whitespace
mrmetadata.py:497:5: E303 too many blank lines (2)
mrmetadata.py:498:1: W293 blank line contains whitespace
mrmetadata.py:502:1: W293 blank line contains whitespace
mrmetadata.py:507:1: W293 blank line contains whitespace
mrmetadata.py:521:1: W293 blank line contains whitespace
mrmetadata.py:522:76: E231 missing whitespace after ','
mrmetadata.py:522:85: E231 missing whitespace after ','
mrmetadata.py:522:100: E231 missing whitespace after ','
mrmetadata.py:523:1: W293 blank line contains whitespace
mrmetadata.py:528:1: W293 blank line contains whitespace
mrmetadata.py:529:1: E265 block comment should start with '# '
mrmetadata.py:529:1: E303 too many blank lines (3)
mrmetadata.py:531:1: E265 block comment should start with '# '
mrmetadata.py:533:1: E302 expected 2 blank lines, found 3
mrmetadata.py:534:1: W293 blank line contains whitespace
mrmetadata.py:538:1: W293 blank line contains whitespace
mrmetadata.py:543:1: E303 too many blank lines (3)
mrmetadata.py:544:1: W293 blank line contains whitespace
mrmetadata.py:546:1: W293 blank line contains whitespace
mrmetadata.py:547:76: W291 trailing whitespace
mrmetadata.py:548:58: E231 missing whitespace after ','
mrmetadata.py:548:67: E231 missing whitespace after ','
mrmetadata.py:548:82: E231 missing whitespace after ','
mrmetadata.py:552:1: E265 block comment should start with '# '
mrmetadata.py:554:1: E265 block comment should start with '# '
mrmetadata.py:557:1: W293 blank line contains whitespace
mrmetadata.py:562:40: W291 trailing whitespace
mrmetadata.py:568:1: E302 expected 2 blank lines, found 1
mrmetadata.py:569:1: W293 blank line contains whitespace
mrmetadata.py:574:40: W291 trailing whitespace
mrmetadata.py:582:1: W293 blank line contains whitespace
mrmetadata.py:585:1: W293 blank line contains whitespace
mrmetadata.py:587:1: W293 blank line contains whitespace
mrmetadata.py:598:1: W293 blank line contains whitespace
mrmetadata.py:604:1: E265 block comment should start with '# '
mrmetadata.py:606:1: E265 block comment should start with '# '
mrmetadata.py:610:1: W293 blank line contains whitespace
mrmetadata.py:611:42: E201 whitespace after '('
mrmetadata.py:611:54: E202 whitespace before ')'
mrmetadata.py:612:1: W293 blank line contains whitespace
mrmetadata.py:623:1: W293 blank line contains whitespace
mrmetadata.py:627:129: W291 trailing whitespace
mrmetadata.py:628:1: W293 blank line contains whitespace
mrmetadata.py:629:24: E201 whitespace after '{'
mrmetadata.py:633:35: E201 whitespace after '('
mrmetadata.py:633:51: E202 whitespace before ')'
mrmetadata.py:643:1: E303 too many blank lines (3)
mrmetadata.py:643:17: E211 whitespace before '('
mrmetadata.py:643:19: E201 whitespace after '('
mrmetadata.py:643:48: E202 whitespace before ')'
mrmetadata.py:654:37: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:654:39: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:654:59: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:654:61: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:654:76: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:654:78: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:658:13: E128 continuation line under-indented for visual indent
mrmetadata.py:659:13: E128 continuation line under-indented for visual indent
mrmetadata.py:660:13: E128 continuation line under-indented for visual indent
mrmetadata.py:661:13: E128 continuation line under-indented for visual indent
mrmetadata.py:662:13: E128 continuation line under-indented for visual indent
mrmetadata.py:663:13: E128 continuation line under-indented for visual indent
mrmetadata.py:664:13: E128 continuation line under-indented for visual indent
mrmetadata.py:665:1: W293 blank line contains whitespace
mrmetadata.py:671:112: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:671:114: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:672:1: W293 blank line contains whitespace
mrmetadata.py:675:42: E201 whitespace after '('
mrmetadata.py:675:59: E202 whitespace before ')'
mrmetadata.py:677:43: E211 whitespace before '('
mrmetadata.py:677:45: E201 whitespace after '('
mrmetadata.py:678:1: W293 blank line contains whitespace
mrmetadata.py:679:14: E201 whitespace after '{'
mrmetadata.py:683:13: E124 closing bracket does not match visual indentation
mrmetadata.py:684:1: W293 blank line contains whitespace
mrmetadata.py:685:24: E201 whitespace after '{'
mrmetadata.py:685:31: E203 whitespace before ':'
mrmetadata.py:686:21: E128 continuation line under-indented for visual indent
mrmetadata.py:687:21: E128 continuation line under-indented for visual indent
mrmetadata.py:688:21: E128 continuation line under-indented for visual indent
mrmetadata.py:688:46: E203 whitespace before ':'
mrmetadata.py:689:21: E128 continuation line under-indented for visual indent
mrmetadata.py:689:37: E203 whitespace before ':'
mrmetadata.py:691:35: E201 whitespace after '('
mrmetadata.py:691:51: E202 whitespace before ')'
mrmetadata.py:700:109: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:700:111: E251 unexpected spaces around keyword / parameter equals
mrmetadata.py:702:42: E201 whitespace after '('
mrmetadata.py:702:59: E202 whitespace before ')'
mrmetadata.py:704:43: E211 whitespace before '('
mrmetadata.py:704:45: E201 whitespace after '('
mrmetadata.py:705:1: W293 blank line contains whitespace
mrmetadata.py:706:14: E201 whitespace after '{'
mrmetadata.py:710:13: E124 closing bracket does not match visual indentation
mrmetadata.py:712:24: E201 whitespace after '{'
mrmetadata.py:712:31: E203 whitespace before ':'
mrmetadata.py:713:21: E128 continuation line under-indented for visual indent
mrmetadata.py:714:21: E128 continuation line under-indented for visual indent
mrmetadata.py:715:21: E128 continuation line under-indented for visual indent
mrmetadata.py:715:46: E203 whitespace before ':'
mrmetadata.py:716:21: E128 continuation line under-indented for visual indent
mrmetadata.py:717:21: E128 continuation line under-indented for visual indent
mrmetadata.py:717:37: E203 whitespace before ':'
mrmetadata.py:719:35: E201 whitespace after '('
mrmetadata.py:719:51: E202 whitespace before ')'
mrmetadata.py:729:1: E303 too many blank lines (3)
mrmetadata.py:729:18: E211 whitespace before '('
mrmetadata.py:729:20: E201 whitespace after '('
mrmetadata.py:729:27: E202 whitespace before ')'
mrmetadata.py:730:30: E201 whitespace after '('
mrmetadata.py:730:37: E202 whitespace before ')'
mrmetadata.py:736:1: E265 block comment should start with '# '
mrmetadata.py:739:1: W293 blank line contains whitespace
mrmetadata.py:741:1: W293 blank line contains whitespace
mrmetadata.py:743:1: W293 blank line contains whitespace
mrmetadata.py:745:1: W293 blank line contains whitespace
mrmetadata.py:747:1: W293 blank line contains whitespace
mrmetadata.py:749:1: W293 blank line contains whitespace
mrmetadata.py:751:1: W293 blank line contains whitespace
mrmetadata.py:753:1: W293 blank line contains whitespace
mrmetadata.py:756:1: W293 blank line contains whitespace
mrmetadata.py:758:27: W292 no newline at end of file
```
